### PR TITLE
Allow disabling EIP for private loadbalancing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,19 +8,25 @@ data "opentelekomcloud_lb_flavor_v3" "layer7_flavor" {
   name  = var.layer7_flavor
 }
 
-resource "opentelekomcloud_lb_loadbalancer_v3" "elb" {
-  name        = "${var.name_prefix}-ELB"
-  description = "Dedicated ELB instance with public IP."
-  subnet_id   = var.subnet_id
-  network_ids = var.network_ids
+resource "opentelekomcloud_lb_loadbalancer_v3" "loadbalancer" {
+  name             = "${var.name_prefix}-lb"
+  description      = "Dedicated loadbalancer instance with public IP."
+  subnet_id        = var.subnet_id
+  network_ids      = var.network_ids
+  ip_target_enable = var.ip_target_enable
 
   l4_flavor = length(var.layer4_flavor) == 0 ? null : data.opentelekomcloud_lb_flavor_v3.layer4_flavor[0].id
   l7_flavor = length(var.layer7_flavor) == 0 ? null : data.opentelekomcloud_lb_flavor_v3.layer7_flavor[0].id
 
   availability_zones = var.availability_zones
-  public_ip {
-    id = opentelekomcloud_vpc_eip_v1.ingress_eip.id
+
+  dynamic "public_ip" {
+    for_each = opentelekomcloud_vpc_eip_v1.ingress_eip
+    content {
+      id = public_ip.value.id
+    }
   }
+
   tags = var.tags
   lifecycle {
     ignore_changes = [router_id]
@@ -28,9 +34,10 @@ resource "opentelekomcloud_lb_loadbalancer_v3" "elb" {
 }
 
 resource "opentelekomcloud_vpc_eip_v1" "ingress_eip" {
+  count = var.bandwidth == 0 ? 0 : 1
   bandwidth {
     charge_mode = "traffic"
-    name        = "${var.name_prefix}-ELB"
+    name        = "${var.name_prefix}-lb"
     share_type  = "PER"
     size        = var.bandwidth
   }

--- a/output.tf
+++ b/output.tf
@@ -1,11 +1,11 @@
 output "elb_id" {
-  value = opentelekomcloud_lb_loadbalancer_v3.elb.id
+  value = opentelekomcloud_lb_loadbalancer_v3.loadbalancer.id
 }
 
 output "elb_private_ip" {
-  value = opentelekomcloud_lb_loadbalancer_v3.elb.vip_address
+  value = opentelekomcloud_lb_loadbalancer_v3.loadbalancer.vip_address
 }
 
 output "elb_public_ip" {
-  value = opentelekomcloud_vpc_eip_v1.ingress_eip.publicip[0].ip_address
+  value = try(opentelekomcloud_vpc_eip_v1.ingress_eip[0].publicip[0].ip_address, null)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "availability_zones" {
 variable "bandwidth" {
   type        = number
   default     = 100
-  description = "The bandwidth size. The value ranges from 1 to 1000 Mbit/s."
+  description = "The EIP bandwidth size. The value for a public loadbalancer ranges from 1 to 1000 Mbit/s. 0 disables the EIP, making the loadbalancer private."
 }
 
 variable "subnet_id" {
@@ -28,6 +28,12 @@ variable "subnet_id" {
 variable "network_ids" {
   type        = list(string)
   description = "Network IDs to use for loadbalancer backends. Default: <obtained from subnet_id>"
+}
+
+variable "ip_target_enable" {
+  type        = bool
+  description = "Enable using ip as backend feature."
+  default     = false
 }
 
 variable "layer7_flavor" {


### PR DESCRIPTION
feat(eip): allow disabling EIP for private loadbalancing
feat(ipbackends): exposed the loadbalancer flag for enabling ip as backend feature as input
feat(naming): renamed elb resources to loadbalancer to better differentiate with shared elb resources